### PR TITLE
Fixed broken URL matching due to statefulness of RegExp objects.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ function findHandler(requestURL) {
     if (typeof h.url === "string") {
       return h.url === requestURL;
     } else if (h.url.test !== void 0) {
-      return h.url.test(requestURL)
+      return requestURL && requestURL.match && requestURL.match(h.url);
     }
     return false;
   });


### PR DESCRIPTION
RegExp objects are stateful. E.g.:

```
> var r = /test/g;
< undefined
> r.test('test')
< true
> r.test('test')
< false
```

If someone uses a url pattern with the 'g' flag, the findHandler function will return different results on each use. I don't know if it's really common to use the 'g' flag for a URL-matching pattern, but I don't think the current behaviour in farfetched is useful.
